### PR TITLE
radvdump: show routes with prefixlen > 64

### DIFF
--- a/radvdump.c
+++ b/radvdump.c
@@ -352,7 +352,8 @@ static void print_ff(unsigned char *msg, int len, struct sockaddr_in6 *addr, int
 				} else {
 					struct in6_addr addr;
 					memset(&addr, 0, sizeof(addr));
-					memcpy(&addr, &rinfo->nd_opt_ri_prefix, 8);
+					if (rinfo->nd_opt_ri_len > 1)
+						memcpy(&addr, &rinfo->nd_opt_ri_prefix, (rinfo->nd_opt_ri_len - 1) * 8);
 					addrtostr(&addr, prefix_str, sizeof(prefix_str));
 					printf("\n\troute %s/%d\n\t{\n", prefix_str, rinfo->nd_opt_ri_prefix_len);
 				}


### PR DESCRIPTION
Current radvdump code blindly copies over eight bytes of route prefix
but its size in bytes can actually be zero, eight or sixteen.

Use the following `/etc/radvd.conf` to reproduce:

    interface eth0 {
        AdvSendAdvert on;
        MinRtrAdvInterval 3;
        MaxRtrAdvInterval 4;
        route 2001:db8:0:0:11::/80 {};
    };

Output before the change:

    route 2001:db8::/80
    {
        AdvRoutePreference medium;
        AdvRouteLifetime 12;
    }; # End of route definition

Output after the change:

    route 2001:db8:0:0:11::/80
    {
        AdvRoutePreference medium;
        AdvRouteLifetime 12;
    }; # End of route definition

See also:

 * https://bugzilla.redhat.com/show_bug.cgi?id=1188891
 * https://tools.ietf.org/html/rfc4191#section-2.3