### PR TITLE
valid lifetimes on deprecation not RFC4862  compliant

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -126,7 +126,7 @@
 #define MAX_PrefixLen			128
 
 /* SLAAC (RFC4862) Constants and Derived Values */
-#define MIN_AdvValidLifetime		7203	/* slight >2 hours in secs */
+#define MIN_AdvValidLifetime		7200	/* 2 hours in secs */
 
 /*
  * Mobile IPv6 extensions, off by default

--- a/send.c
+++ b/send.c
@@ -210,7 +210,11 @@ static void add_prefix(struct safe_buffer * sb, struct AdvPrefix const *prefix, 
 
 			if (cease_adv && prefix->DeprecatePrefixFlag) {
 				/* RFC4862, 5.5.3, step e) */
-				pinfo.nd_opt_pi_valid_time = htonl(MIN_AdvValidLifetime);
+				if (prefix->curr_validlft < MIN_AdvValidLifetime) {
+					pinfo.nd_opt_pi_valid_time = htonl(prefix->curr_validlft);
+				} else {
+					pinfo.nd_opt_pi_valid_time = htonl(MIN_AdvValidLifetime);
+				}
 				pinfo.nd_opt_pi_preferred_time = 0;
 			} else {
 				pinfo.nd_opt_pi_valid_time = htonl(prefix->curr_validlft);

--- a/send.c
+++ b/send.c
@@ -129,7 +129,7 @@ static void update_iface_times(struct Interface * iface)
 {
 	struct timespec last_time = iface->times.last_ra_time;
 	clock_gettime(CLOCK_MONOTONIC, &iface->times.last_ra_time);
-	time_t secs_since_last_ra = timespecdiff(&iface->times.last_ra_time, &last_time);
+	time_t secs_since_last_ra = timespecdiff(&iface->times.last_ra_time, &last_time) / 1000;
 
 	if (secs_since_last_ra < 0) {
 		secs_since_last_ra = 0;


### PR DESCRIPTION
this pull request is related to 3 lifetime topics:

1. on prefix deprecation the lifetime is set to 7203 seconds instead of 7200 seconds. This is only a minor issue, but some protocol testers like CDRouter are complaining about values greater than 7200s

2. The remaining lifetime is set to 7203 seconds on deprecation even if the lifetime was less before. So actually  the lifetime is incremented on deprecation

3. the config option "DecrementLifetimes" will currently not work if the remaining lifetime is less than 16000 seconds. The reason is, that the time since last RA is measured in milliseconds but afterwards the value is compared with a value which is stored in seconds.