### PR TITLE
Prefix deprecation according to  rfc4862

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -126,7 +126,7 @@
 #define MAX_PrefixLen			128
 
 /* SLAAC (RFC4862) Constants and Derived Values */
-#define MIN_AdvValidLifetime		7203	/* slight >2 hours in secs */
+#define MIN_AdvValidLifetime		7200	/* hours in secs */
 
 /*
  * Mobile IPv6 extensions, off by default

--- a/send.c
+++ b/send.c
@@ -217,7 +217,15 @@ int send_ra(struct Interface *iface, struct in6_addr *dest)
 
 			if (iface->cease_adv && prefix->DeprecatePrefixFlag) {
 				/* RFC4862, 5.5.3, step e) */
-				pinfo->nd_opt_pi_valid_time = htonl(MIN_AdvValidLifetime);
+				if (prefix->curr_validlft < MIN_AdvValidLifetime) {
+					if (prefix->DecrementLifetimesFlag) {
+						decrement_lifetime(secs_since_last_ra,
+						&prefix->curr_validlft);
+					}
+					pinfo->nd_opt_pi_valid_time = htonl(prefix->curr_validlft);
+				} else {
+					pinfo->nd_opt_pi_valid_time = htonl(MIN_AdvValidLifetime);
+				}
 				pinfo->nd_opt_pi_preferred_time = 0;
 			} else {
 				if (prefix->DecrementLifetimesFlag) {


### PR DESCRIPTION
two issues:
1. on deprecation the remaining valid lifetime is set to two hours (even if the timer was less before), so the lifetime will grow on deprecation
2. RFC 4862 want's the remainig valid lifetime to be set to two hours (7200s), radvd uses 7203s - this has no practical effect but some protocol testers like CDRouter are complaining if the timer is less than 7200s (so radvd based devices will be red - not RFC compliant) 