### PR TITLE
Fix comparing address list in process_netlink_msg()

### DIFF
--- a/netlink.c
+++ b/netlink.c
@@ -111,7 +111,7 @@ void process_netlink_msg(int sock, struct Interface * ifaces)
 				struct in6_addr *if_addrs = NULL;
 				int count = get_iface_addrs(iface->props.name, NULL, &if_addrs);
 
-				if (count != iface->props.addrs_count &&
+				if (count != iface->props.addrs_count ||
 					0 != memcmp(if_addrs, iface->props.if_addrs, count * sizeof(struct in6_addr))) {
 					dlog(LOG_DEBUG, 3, "netlink: %s, ifindex %d, addresses are different",
 						ifname, ifaddr->ifa_index);


### PR DESCRIPTION
When starting radvd in parallel to adding addresses and bringing an
interface up, a segmentation fault was observed:

	IPv6: ADDRCONF(NETDEV_UP): enp63s0: link is not ready
	enp5s9: Preferred AP (SIOCSIWAP) is used only in Managed mode when host_roaming is enabled
	enp5s9: Host AP mode does not support 'Any' essid
	sit: IPv6 over IPv4 tunneling driver
	radvd[1544]: segfault at 0 ip 00007f3307fdec78 sp 00007ffecd6363e8 error 4 in libc-2.22.so[7f3307f5a000+198000]
	tg3 0000:3f:00.0 enp63s0: Link is up at 100 Mbps, full duplex
	tg3 0000:3f:00.0 enp63s0: Flow control is on for TX and on for RX
	IPv6: ADDRCONF(NETDEV_CHANGE): enp63s0: link becomes ready

The core dump showed:

	(gdb) bt full
	#0  __memcmp_sse2 () at ../sysdeps/x86_64/multiarch/../memcmp.S:261
	No locals.
	#1  0x000000000040ff24 in process_netlink_msg (sock=5, ifaces=0x1ab4110) at netlink.c:115
		if_addrs = 0x1ab1db0
		count = 2
		ifaddr = 0x7ffecd6364e0
		ifname = 0x7ffecd6364c0 "enp5s9"
		iface = 0x1ab4110
		ifnamebuf = "enp5s9\000\000\000\000\000\000\000\000\000"
		nh = 0x7ffecd6364d0
		buf = "H\000\000\000\024", '\000' <repeats 11 times>, "\n@\200\375\005\000\000\000\024\000\001\000\376\200\000\000\000\000\000\000\002`\263\377\376dn\367\024\000\006\000\377\377\377\377\377\377\377\377p\005\000\000p\005\000\000\b\000\b\000\200\000\000\000ce\000\000\b\000\033\000\000\000\000\000\b\000\036\000\000\000\000\000\b\000\037\000\001\000\000\000\b\000\005\000\000\000\000\000\005\000!\000\001\000\000\000\f\000\006\000noqueue\000\b\000#\000\000\000\000\000\005\000'\000\000\000\000\000$\000\016", '\000' <repeats 33 times>, "\b\000\001\000Z\262\321\202\b\000\002\000\000\000\000\000`\000\a", '\000' <repeats 93 times>...
		iov = {iov_base = 0x7ffecd6364d0, iov_len = 4096}
		sa = {nl_family = 16, nl_pad = 0, nl_pid = 0, nl_groups = 256}
		msg = {msg_name = 0x7ffecd636460, msg_namelen = 12, msg_iov = 0x7ffecd636470, msg_iovlen = 1, msg_control = 0x0, msg_controllen = 0, msg_flags = 0}
		len = 72
	#2  0x0000000000406c1b in main_loop (sock=3, ifaces=0x1ab4110, conf_path=0x7ffecd63991a "/etc/radvd.conf") at radvd.c:520

The code crashed in process_netlink_msg() when doing memcp() on
NULL iface->props.if_addrs. At the same time iface->props.if_count was
0, count was 2:

       struct in6_addr *if_addrs = NULL;
        int count = get_iface_addrs(iface->props.name, NULL, &if_addrs);

        if (count != iface->props.addrs_count &&
          0 != memcmp(if_addrs, iface->props.if_addrs, count * sizeof(struct in6_addr))) {
          dlog(LOG_DEBUG, 3, "netlink: %s, ifindex %d, addresses are different",
            ifname, ifaddr->ifa_index);
          touch_iface(iface);
        } else {

The code tries to catch a case when list of address changed. Either the
number of addresses or the value of the addresses. Therefore the logical
operator should be "||" and not "&&".

This patch fixes the typo that lead to logical error and dereferencing
NULL when the original address list was still empty.