### PR TITLE
6LoWPAN for upstream fixes

### DIFF
--- a/device-linux.c
+++ b/device-linux.c
@@ -22,6 +22,10 @@
 #define IPV6_ADDR_LINKLOCAL   0x0020U
 #endif
 
+#ifndef ARPHRD_6LOWPAN
+#define ARPHRD_6LOWPAN	825	/* IPv6 over LoWPAN */
+#endif
+
 static char const *hwstr(unsigned short sa_family);
 
 /*
@@ -79,12 +83,10 @@ int update_device_info(int sock, struct Interface *iface)
 		iface->sllao.if_maxmtu = -1;
 		break;
 #endif				/* ARPHDR_ARCNET */
-#ifdef ARPHRD_IEEE802154
-	case ARPHRD_IEEE802154:
+	case ARPHRD_6LOWPAN:
 		iface->sllao.if_hwaddr_len = 64;
 		iface->sllao.if_prefix_len = 64;
 		break;
-#endif
 	default:
 		iface->sllao.if_hwaddr_len = -1;
 		iface->sllao.if_prefix_len = -1;
@@ -382,6 +384,9 @@ static char const *hwstr(unsigned short sa_family)
 		rc = "ARPHRD_IEEE802154_PHY";
 		break;
 #endif
+	case ARPHRD_6LOWPAN:
+		rc = "ARPHRD_6LOWPAN";
+		break;
 	case ARPHRD_VOID:
 		rc = "ARPHRD_VOID";
 		break;

--- a/netlink.c
+++ b/netlink.c
@@ -32,6 +32,68 @@
 #define SOL_NETLINK	270
 #endif
 
+struct iplink_req {
+	struct nlmsghdr		n;
+	struct ifinfomsg	i;
+	char			buf[1024];
+};
+
+int netlink_get_device_addr_len(struct Interface *iface)
+{
+	struct iplink_req req = {};
+	struct iovec iov = { &req, sizeof(req) };
+	struct sockaddr_nl sa = {};
+	struct msghdr msg = { (void *)&sa, sizeof(sa), &iov, 1, NULL, 0, 0 };
+	int sock, len, addr_len = -1;
+	unsigned short type;
+	char answer[32768];
+	struct rtattr *tb;
+
+	/* nl_pid (for linux kernel) and nl_groups (unicast) should be zero */
+	sa.nl_family = AF_NETLINK;
+	req.n.nlmsg_len = NLMSG_LENGTH(sizeof(struct ifinfomsg));
+	req.n.nlmsg_flags = NLM_F_REQUEST;
+	req.n.nlmsg_type = RTM_GETLINK;
+	req.i.ifi_index = iface->props.if_index;
+
+	sock = netlink_socket();
+	if (sock == -1)
+		return -1;
+
+	len = sendmsg(sock, &msg, 0);
+	if (len == -1) {
+		flog(LOG_ERR, "netlink: sendmsg for addr_len failed: %s", strerror(errno));
+		goto out;
+	}
+
+	iov.iov_base = answer;
+	iov.iov_len = sizeof(answer);
+	len = recvmsg(sock, &msg, 0);
+	if (len == -1) {
+		flog(LOG_ERR, "netlink: recvmsg for addr_len failed: %s", strerror(errno));
+		goto out;
+	}
+
+	if (len < NLMSG_LENGTH(sizeof(struct ifinfomsg)))
+		goto out;
+	len -= NLMSG_LENGTH(sizeof(struct ifinfomsg));
+
+	tb = (struct rtattr *)(answer + NLMSG_LENGTH(sizeof(struct ifinfomsg)));
+	while (RTA_OK(tb, len)) {
+		type = tb->rta_type & ~NLA_F_NESTED;
+		if (type == IFLA_ADDRESS) {
+			addr_len = RTA_PAYLOAD(tb);
+			break;
+		}
+		tb = RTA_NEXT(tb, len);
+	}
+
+out:
+	close(sock);
+
+	return addr_len;
+}
+
 void process_netlink_msg(int sock, struct Interface * ifaces)
 {
 	char buf[4096];

--- a/netlink.h
+++ b/netlink.h
@@ -17,5 +17,6 @@
 
 #include "radvd.h"
 
+int netlink_get_device_addr_len(struct Interface *iface);
 void process_netlink_msg(int sock, struct Interface * ifaces);
 int netlink_socket(void);


### PR DESCRIPTION
this pull request contains the following changes:

- Change ARPHRD_IEEE802154 to ARPHRD_6LOWPAN

This ARPHRD is shared for all 6LoWPAN interfaces, doesn't depend on link-layer.

- Add netlink mechanism to get device address length

To getting the device address length, we cannot do a mapping from ARPHRD to device address length, because the device address length can be different for ARPHRD_6LOWPAN. Tho get the device address length we check the payload length of IFLA_ADDRESS of rtnetlink interface.

Please merge this into radvd upstream implementation.