### PR TITLE
AdvRASrcAddress: selection of RA source address

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+2016/11/11	Allow selection of RA source address. <Robin H. Johnson>
+
 2016/09/24	Release v2.15
 
 2016/09/18	Moved auto prefix code from config file parse to send_ra.

--- a/device-common.c
+++ b/device-common.c
@@ -174,6 +174,26 @@ int setup_iface_addrs(struct Interface *iface)
 			addrtostr(&iface->props.if_addrs[i], addr_str, sizeof(addr_str));
 			dlog(LOG_DEBUG, 4, "%s address: %s", iface->props.name, addr_str);
 		}
+		/* AdvRASrcAddress: allow operator selection of RA source address */
+		if(iface->AdvRASrcAddressList != NULL) {
+			iface->props.if_addr_rasrc = NULL;
+			for (struct AdvRASrcAddress * current = iface->AdvRASrcAddressList; current; current = current->next) {
+				for (int i = 0; i < iface->props.addrs_count; i++) {
+					struct in6_addr cmp_addr = iface->props.if_addrs[i];
+					if (0 == memcmp(&cmp_addr, &current->address, sizeof(struct in6_addr))) {
+						addrtostr(&(cmp_addr), addr_str, sizeof(addr_str));
+						dlog(LOG_DEBUG, 4, "AdvRASrcAddress selecting: %s", addr_str);
+						iface->props.if_addr_rasrc = &iface->props.if_addrs[i];
+						break;
+					}
+				}
+				if(NULL != iface->props.if_addr_rasrc)
+					break;
+			}
+		} else {
+			/* AdvRASrcAddress default: Just take the first link-local */
+			iface->props.if_addr_rasrc = &iface->props.if_addr;
+		}
 	} else {
 		if (iface->IgnoreIfMissing)
 			dlog(LOG_DEBUG, 4, "no linklocal address configured on %s", iface->props.name);

--- a/gram.y
+++ b/gram.y
@@ -51,6 +51,7 @@
 %token		T_CLIENTS
 %token		T_LOWPANCO
 %token		T_ABRO
+%token		T_RASRCADDRESS
 
 %token	<str>	STRING
 %token	<num>	NUMBER
@@ -123,13 +124,14 @@
 
 %type	<str>	name
 %type	<pinfo> prefixdef
-%type	<ainfo> clientslist v6addrlist
+%type	<ainfo> clientslist v6addrlist_clients
 %type	<rinfo>	routedef
 %type	<rdnssinfo> rdnssdef
 %type	<dnsslinfo> dnssldef
 %type   <lowpancoinfo> lowpancodef
 %type   <abroinfo> abrodef
 %type   <num>	number_or_infinity
+%type	<rasrcaddressinfo> rasrcaddresslist v6addrlist_rasrcaddress
 
 %union {
 	unsigned int		num;
@@ -144,6 +146,7 @@
 	struct Clients		*ainfo;
 	struct AdvLowpanCo	*lowpancoinfo;
 	struct AdvAbro		*abroinfo;
+	struct AdvRASrcAddress	*rasrcaddressinfo;
 };
 
 %{
@@ -227,6 +230,7 @@ ifaceparam 	: ifaceval
 		| dnssldef 	{ ADD_TO_LL(struct AdvDNSSL, AdvDNSSLList, $1); }
 		| lowpancodef   { ADD_TO_LL(struct AdvLowpanCo, AdvLowpanCoList, $1); }
 		| abrodef       { ADD_TO_LL(struct AdvAbro, AdvAbroList, $1); }
+		| rasrcaddresslist { ADD_TO_LL(struct AdvRASrcAddress, AdvRASrcAddressList, $1); }
 		;
 
 ifaceval	: T_MinRtrAdvInterval NUMBER ';'
@@ -327,13 +331,13 @@ ifaceval	: T_MinRtrAdvInterval NUMBER ';'
 		}
 		;
 
-clientslist	: T_CLIENTS '{' v6addrlist '}' ';'
+clientslist	: T_CLIENTS '{' v6addrlist_clients '}' ';'
 		{
 			$$ = $3;
 		}
 		;
 
-v6addrlist	: IPV6ADDR ';'
+v6addrlist_clients	: IPV6ADDR ';'
 		{
 			struct Clients *new = calloc(1, sizeof(struct Clients));
 			if (new == NULL) {
@@ -344,7 +348,7 @@ v6addrlist	: IPV6ADDR ';'
 			memcpy(&(new->Address), $1, sizeof(struct in6_addr));
 			$$ = new;
 		}
-		| v6addrlist IPV6ADDR ';'
+		| v6addrlist_clients IPV6ADDR ';'
 		{
 			struct Clients *new = calloc(1, sizeof(struct Clients));
 			if (new == NULL) {
@@ -358,6 +362,36 @@ v6addrlist	: IPV6ADDR ';'
 		}
 		;
 
+rasrcaddresslist	: T_RASRCADDRESS '{' v6addrlist_rasrcaddress '}' ';'
+		{
+			$$ = $3;
+		}
+		;
+
+v6addrlist_rasrcaddress	: IPV6ADDR ';'
+		{
+			struct AdvRASrcAddress *new = calloc(1, sizeof(struct AdvRASrcAddress));
+			if (new == NULL) {
+				flog(LOG_CRIT, "calloc failed: %s", strerror(errno));
+				ABORT;
+			}
+
+			memcpy(&(new->address), $1, sizeof(struct in6_addr));
+			$$ = new;
+		}
+		| v6addrlist_rasrcaddress IPV6ADDR ';'
+		{
+			struct AdvRASrcAddress *new = calloc(1, sizeof(struct AdvRASrcAddress));
+			if (new == NULL) {
+				flog(LOG_CRIT, "calloc failed: %s", strerror(errno));
+				ABORT;
+			}
+
+			memcpy(&(new->address), $2, sizeof(struct in6_addr));
+			new->next = $1;
+			$$ = new;
+		}
+		;
 
 prefixdef	: prefixhead optional_prefixplist ';'
 		{

--- a/interface.c
+++ b/interface.c
@@ -90,6 +90,12 @@ int setup_iface(int sock, struct Interface *iface)
 		return -1;
 	}
 
+	/* Check if we a usable RA source address */
+	if(iface->props.if_addr_rasrc == NULL) {
+		dlog(LOG_DEBUG, 5, "no configured AdvRASrcAddress present, skipping send");
+		return -1;
+	}
+
 	/* join the allrouters multicast group so we get the solicitations */
 	if (setup_allrouters_membership(sock, iface) < 0) {
 		return -1;

--- a/radvd.conf.5.man
+++ b/radvd.conf.5.man
@@ -32,6 +32,7 @@ The file contains one or more interface definitions of the form:
 	list of RDNSS definitions
 	list of DNSSL definitions
 	list of ABRO definitions
+	list of acceptable RA source addresses
 .B };
 .fi
 
@@ -103,6 +104,18 @@ The definitions are of the form:
 
 .nf
 .BR clients " " {
+        list of IPv6 addresses
+.B };
+.fi
+
+By default radvd will use the first link-local address for the interface as the
+source address for route advertisements. This can be overwritten by manually
+setting the list of acceptable source addresses. If done, radvd will use the
+first address from the interface that is present in the configured source
+addresses only. This functionality will NOT spoof the source address, but may be useful in combination with VRRP or other functionality that 
+
+.nf
+.BR AdvRASrcAddress " " {
         list of IPv6 addresses
 .B };
 .fi

--- a/radvd.h
+++ b/radvd.h
@@ -69,6 +69,7 @@ struct Interface {
 		struct in6_addr if_addr; /* the first link local addr */
 		struct in6_addr *if_addrs; /* all the addrs */
 		int addrs_count;
+		struct in6_addr *if_addr_rasrc; /* selected AdvRASrcAddress or NULL */
 	} props;
 
 	struct ra_header_info {
@@ -116,6 +117,8 @@ struct Interface {
 
 	struct AdvLowpanCo *AdvLowpanCoList;
 	struct AdvAbro *AdvAbroList;
+
+	struct AdvRASrcAddress *AdvRASrcAddressList;
 
 	int lineno; /* On what line in the config file was this iface defined? */
 };
@@ -205,6 +208,12 @@ struct AdvAbro {
 	struct in6_addr LBRaddress;
 
 	struct AdvAbro *next;
+};
+
+struct AdvRASrcAddress {
+	struct in6_addr address;
+
+	struct AdvRASrcAddress *next;
 };
 
 /* Mobile IPv6 extensions */
@@ -320,7 +329,7 @@ size_t safe_buffer_pad(struct safe_buffer * sb, size_t count);
 ssize_t readn(int fd, void *buf, size_t count);
 ssize_t writen(int fd, const void *buf, size_t count);
 struct safe_buffer * new_safe_buffer(void);
-void addrtostr(struct in6_addr *, char *, size_t);
+void addrtostr(struct in6_addr const *, char *, size_t);
 void safe_buffer_free(struct safe_buffer * sb);
 
 /* privsep.c */

--- a/scanner.l
+++ b/scanner.l
@@ -50,6 +50,7 @@ DNSSL			{ return T_DNSSL; }
 clients			{ return T_CLIENTS; }
 lowpanco		{ return T_LOWPANCO; }
 abro			{ return T_ABRO; }
+AdvRASrcAddress	{ return T_RASRCADDRESS; }
 
 IgnoreIfMissing		{ return T_IgnoreIfMissing; }
 AdvSendAdvert		{ return T_AdvSendAdvert; }

--- a/send.c
+++ b/send.c
@@ -91,7 +91,7 @@ int send_ra_forall(int sock, struct Interface *iface, struct in6_addr *dest)
 	/* If we refused a client's solicitation, log it if debugging is high enough */
 	if (get_debuglevel() >= 5) {
 		char address_text[INET6_ADDRSTRLEN] = { "" };
-		inet_ntop(AF_INET6, dest, address_text, INET6_ADDRSTRLEN);
+		addrtostr(dest, address_text, INET6_ADDRSTRLEN);
 		dlog(LOG_DEBUG, 5, "Not answering request from %s, not configured", address_text);
 	}
 
@@ -728,9 +728,11 @@ static int send_ra(int sock, struct Interface *iface, struct in6_addr const *des
 
 	update_iface_times(iface);
 
-	char address_text[INET6_ADDRSTRLEN] = { "" };
-	inet_ntop(AF_INET6, dest, address_text, INET6_ADDRSTRLEN);
-	dlog(LOG_DEBUG, 5, "sending RA to %s on %s", address_text, iface->props.name);
+	char dest_text[INET6_ADDRSTRLEN] = { "" };
+	char src_text[INET6_ADDRSTRLEN] = { "" };
+	addrtostr(dest, dest_text, INET6_ADDRSTRLEN);
+	addrtostr(iface->props.if_addr_rasrc, src_text, INET6_ADDRSTRLEN);
+	dlog(LOG_DEBUG, 5, "sending RA to %s on %s (%s)", dest_text, iface->props.name, src_text);
 
 	struct safe_buffer safe_buffer = SAFE_BUFFER_INIT;
 
@@ -773,7 +775,7 @@ static int really_send(int sock, struct in6_addr const *dest, struct properties 
 
 	struct in6_pktinfo *pkt_info = (struct in6_pktinfo *)CMSG_DATA(cmsg);
 	pkt_info->ipi6_ifindex = props->if_index;
-	memcpy(&pkt_info->ipi6_addr, &props->if_addr, sizeof(struct in6_addr));
+	memcpy(&pkt_info->ipi6_addr, props->if_addr_rasrc, sizeof(struct in6_addr));
 
 #ifdef HAVE_SIN6_SCOPE_ID
 	if (IN6_IS_ADDR_LINKLOCAL(&addr.sin6_addr) || IN6_IS_ADDR_MC_LINKLOCAL(&addr.sin6_addr))

--- a/util.c
+++ b/util.c
@@ -93,11 +93,11 @@ double rand_between(double lower, double upper)
 }
 
 /* This assumes that str is not null and str_size > 0 */
-void addrtostr(struct in6_addr *addr, char *str, size_t str_size)
+void addrtostr(struct in6_addr const *addr, char *str, size_t str_size)
 {
 	const char *res;
 
-	res = inet_ntop(AF_INET6, (void *)addr, str, str_size);
+	res = inet_ntop(AF_INET6, (void const*)addr, str, str_size);
 
 	if (res == NULL) {
 		flog(LOG_ERR, "addrtostr: inet_ntop: %s", strerror(errno));


### PR DESCRIPTION
New functionality to allow selection of RA IPv6 source address, from the
intersection of specified addresses and the interface addresses.

If there is no overlap between the two sets of addresses, then no RA is
sent.

Fixes: https://github.com/reubenhwk/radvd/issues/45
Signed-off-by: Robin H. Johnson <robbat2@gentoo.org>