### PR TITLE
Fix ExecReload= in radvd service unit configuration

### DIFF
--- a/radvd.service.in
+++ b/radvd.service.in
@@ -11,7 +11,8 @@ After=network.target
 Type=forking
 ExecStartPre=@SBINDIR@/radvd --logmethod stderr_clean --configtest
 ExecStart=@SBINDIR@/radvd --logmethod stderr_clean
-ExecReload=@SBINDIR@/radvd --logmethod stderr_clean --configtest && /bin/kill -HUP $MAINPID
+ExecReload=@SBINDIR@/radvd --logmethod stderr_clean --configtest
+ExecReload=/bin/kill -HUP $MAINPID
 PIDFile=@PATH_RADVD_PID@
 
 # Set the CPU scheduling policy to idle which is for running very low priority background jobs


### PR DESCRIPTION
Commands to restart a system unit are not executed under shell control, but directly (as documented in https://www.freedesktop.org/software/systemd/man/systemd.service.html). This commit fixes the `ExecReload=` definition in the `radvd.service` unit configuration file by breaking the configuration test, followed by send the daemon a SIGHUP into two separate `ExecReload=` commands. `systemd` will automatically execute them sequentially, but the second command will be executed only if the first command succeeded.

I've tested my changes on a Raspberry Pi running Raspbian Jessie and using recent radvd 2.15.