### PR TITLE
Do not use if_arp from glibc if one from linux is usable

### DIFF
--- a/includes.h
+++ b/includes.h
@@ -86,7 +86,7 @@
 #include <net/if_types.h>
 #endif
 
-#if defined(HAVE_NET_IF_ARP_H) && !defined(ARPHRD_ETHER)
+#if defined(HAVE_NET_IF_ARP_H) && !defined(ARPHRD_ETHER) && !defined(HAVE_LINUX_IF_ARP_H)
 #include <net/if_arp.h>
 #endif /* defined(HAVE_NET_IF_ARP_H) && !defined(ARPHRD_ETHER) */
 


### PR DESCRIPTION
In case if both net/if_arp.h and linux/if_arp.h can be used at the
same time (don't have incomplete types etc) the compilation is failed
with type redifiniation error. It worked so far because there were few
incomplete types in linux/if_arp.h dependencies.

Signed-off-by: Pavel Zhukov <pzhukov@redhat.com>

Build logs without patch: https://kojipkgs.fedoraproject.org//work/tasks/5990/18775990/build.log
Build logs with patch applied: https://kojipkgs.fedoraproject.org//work/tasks/6796/18776796/build.log
