### PR TITLE
change handling of default log level

### DIFF
--- a/radvd.c
+++ b/radvd.c
@@ -185,7 +185,8 @@ static pid_t daemonp(int nochdir, int noclose, char const *daemon_pid_file_ident
 int main(int argc, char *argv[])
 {
 	int c;
-	int log_method = L_STDERR_SYSLOG;
+	int log_method = L_SYSLOG;
+	int log_method_set_explicitly = 0;
 	char *logfile = PATH_RADVD_LOG;
 	int facility = LOG_FACILITY;
 	char *username = NULL;
@@ -242,6 +243,7 @@ int main(int argc, char *argv[])
 				fprintf(stderr, "%s: unknown log method: %s\n", pname, optarg);
 				exit(1);
 			}
+			log_method_set_explicitly = 1;
 			break;
 		case 't':
 			chrootdir = strdup(optarg);
@@ -257,6 +259,9 @@ int main(int argc, char *argv[])
 			break;
 		case 'n':
 			daemonize = 0;
+			if (!log_method_set_explicitly) {
+				log_method = L_STDERR_SYSLOG;
+			}
 			break;
 		case 'h':
 			usage(pname);


### PR DESCRIPTION
The default behavior is to daemonize, however the default log level is
L_STDERR_SYSLOG which leaves STDERR bleeding into the console. Thus,
change the default log method to L_SYSLOG (which fits daemonizing) and
automatically change it to L_STDERR_SYSLOG if --nodaemon was specified
on the command-line. However, the latter only takes effect, if the log
method wasn't specified explicitly.

Fixes #71.