### PR TITLE
Check forwarding on interface

### DIFF
--- a/device-bsd44.c
+++ b/device-bsd44.c
@@ -157,3 +157,9 @@ int check_ip6_forwarding(void)
 	dlog(LOG_DEBUG, 4, "checking ipv6 forwarding not supported");
 	return 0;
 }
+
+int check_ip6_iface_forwarding(const char *iface)
+{
+	dlog(LOG_DEBUG, 4, "checking ipv6 forwarding of interface not supported");
+	return -1;
+}

--- a/interface.c
+++ b/interface.c
@@ -164,6 +164,11 @@ int check_iface(struct Interface *iface)
 		flog(LOG_INFO, "using Mobile IPv6 extensions");
 	}
 
+	/* Check forwarding on interface */
+	if (check_ip6_iface_forwarding(iface->props.name) < 1) {
+		flog(LOG_WARNING, "IPv6 forwarding on interface seems to be disabled, but continuing anyway");
+	}
+
 	struct AdvPrefix *prefix = iface->AdvPrefixList;
 	while (!MIPv6 && prefix) {
 		if (prefix->AdvRouterAddr) {

--- a/pathnames.h
+++ b/pathnames.h
@@ -33,6 +33,7 @@
 #define SYSCTL_IP6_FORWARDING CTL_NET, NET_IPV6, NET_IPV6_CONF, NET_PROTO_CONF_ALL, NET_IPV6_FORWARDING
 #define SYSCTL_IP6_AUTOCONFIG CTL_NET, NET_IPV6, NET_IPV6_CONF, NET_PROTO_CONF_ALL, NET_IPV6_AUTOCONF
 #define PROC_SYS_IP6_FORWARDING "/proc/sys/net/ipv6/conf/all/forwarding"
+#define PROC_SYS_IP6_IFACE_FORWARDING "/proc/sys/net/ipv6/conf/%s/forwarding"
 #define PROC_SYS_IP6_AUTOCONFIG "/proc/sys/net/ipv6/conf/%s/autoconf"
 #define PROC_SYS_IP6_LINKMTU "/proc/sys/net/ipv6/conf/%s/mtu"
 #define PROC_SYS_IP6_CURHLIM "/proc/sys/net/ipv6/conf/%s/hop_limit"

--- a/radvd.h
+++ b/radvd.h
@@ -279,6 +279,7 @@ uint64_t next_time_msec(struct Interface const *iface);
 /* device.c */
 int check_device(int sock, struct Interface *);
 int check_ip6_forwarding(void);
+int check_ip6_iface_forwarding(const char *iface);
 int get_v4addr(const char *, unsigned int *);
 int set_interface_curhlim(const char *, uint8_t);
 int set_interface_linkmtu(const char *, uint32_t);


### PR DESCRIPTION
Signed-off-by: Lehner Florian <dev@der-flo.net>

This PR does not fix the issue mentioned in #82. It just checks the forwarding on the interface and writes an information to the log if forwarding is not enabled on the interface.