### PR TITLE
Drop unused variable

### DIFF
--- a/gram.y
+++ b/gram.y
@@ -408,7 +408,6 @@ v6addrlist_rasrcaddress	: IPV6ADDR ';'
 prefixdef	: prefixhead optional_prefixplist ';'
 		{
 			if (prefix) {
-				unsigned int dst;
 
 				if (prefix->AdvPreferredLifetime > prefix->AdvValidLifetime)
 				{


### PR DESCRIPTION
Compillation with Werror=all is now successfull.