### PR TITLE
Write to stderr in non-daemonized mode

### DIFF
--- a/log.c
+++ b/log.c
@@ -32,6 +32,7 @@ int log_open(int method, char const *ident, char const *log, int facility)
 
 	switch (log_method) {
 	case L_NONE:
+	case L_UNSPEC:
 	case L_STDERR:
 		break;
 	case L_STDERR_CLEAN:
@@ -76,6 +77,7 @@ __attribute__((format(printf, 2, 0))) static int vlog(int prio, char const *form
 
 	switch (log_method) {
 	case L_NONE:
+	case L_UNSPEC:
 		break;
 	case L_SYSLOG:
 		syslog(prio, "%s", buff);
@@ -136,6 +138,7 @@ int log_close(void)
 {
 	switch (log_method) {
 	case L_NONE:
+	case L_UNSPEC:
 	case L_STDERR:
 		break;
 	case L_STDERR_SYSLOG:

--- a/log.h
+++ b/log.h
@@ -20,6 +20,7 @@
 #define L_STDERR_SYSLOG 3
 #define L_LOGFILE 4
 #define L_STDERR_CLEAN 5
+#define L_UNSPEC 6
 
 #define LOG_TIME_FORMAT "%b %d %H:%M:%S"
 

--- a/radvd.c
+++ b/radvd.c
@@ -181,7 +181,7 @@ static pid_t daemonp(char const *daemon_pid_file_ident)
 int main(int argc, char *argv[])
 {
 	int c;
-	int log_method = L_STDERR_SYSLOG;
+	int log_method = L_UNSPEC;
 	char *logfile = PATH_RADVD_LOG;
 	int facility = LOG_FACILITY;
 	char *username = NULL;
@@ -294,6 +294,7 @@ int main(int argc, char *argv[])
 			break;
 		case L_STDERR_SYSLOG:
 		case L_NONE:
+		case L_UNSPEC:
 		case L_SYSLOG:
 		case L_LOGFILE:
 		default:
@@ -301,7 +302,8 @@ int main(int argc, char *argv[])
 			break;
 		}
 	}
-
+	if (log_method == L_UNSPEC)
+		log_method = daemonize ? L_STDERR_SYSLOG : L_STDERR;
 	if (log_open(log_method, pname, logfile, facility) < 0) {
 		perror("log_open");
 		exit(1);


### PR DESCRIPTION
When radvd is running in daemonized mode it's ok to write logs in
syslog. However in non-daemonized mode it makes debugging more difficult so
it make sense to use standard error in such cases.

Bug-Url: https://bugzilla.redhat.com/1589806