### PR TITLE
fix wrong assignment of struct msghdr

### DIFF
--- a/netlink.c
+++ b/netlink.c
@@ -43,7 +43,7 @@ int netlink_get_device_addr_len(struct Interface *iface)
 	struct iplink_req req = {};
 	struct iovec iov = {&req, sizeof(req)};
 	struct sockaddr_nl sa = {};
-	struct msghdr msg = {(void *)&sa, sizeof(sa), &iov, 1, NULL, 0, 0};
+	struct msghdr msg = {.msg_name=(void *)&sa, .msg_namelen=sizeof(sa), .msg_iov=&iov, .msg_iovlen=1, .msg_control=NULL, .msg_controllen=0, .msg_flags=0};
 	int sock, len, addr_len = -1;
 	unsigned short type;
 	char answer[32768];
@@ -99,7 +99,7 @@ void process_netlink_msg(int sock, struct Interface *ifaces)
 	char buf[4096];
 	struct iovec iov = {buf, sizeof(buf)};
 	struct sockaddr_nl sa;
-	struct msghdr msg = {(void *)&sa, sizeof(sa), &iov, 1, NULL, 0, 0};
+	struct msghdr msg = {.msg_name=(void *)&sa, .msg_namelen=sizeof(sa), .msg_iov=&iov, .msg_iovlen=1, .msg_control=NULL, .msg_controllen=0, .msg_flags=0};
 	int len = recvmsg(sock, &msg, 0);
 	if (len == -1) {
 		flog(LOG_ERR, "netlink: recvmsg failed: %s", strerror(errno));


### PR DESCRIPTION
depending on the architecure the structure of msghdr may have a
different alignment using padding fields. this will lead to a wrong
assignment of values of the field name isnt specified in initalization.

example of struct msghdr in x86_64 (musl)

struct msghdr {
        void *msg_name;
        socklen_t msg_namelen;
        struct iovec *msg_iov;
        int msg_iovlen, __pad1;
        void *msg_control;
        socklen_t msg_controllen, __pad2;
        int msg_flags;
};

in the current code __pad1 gets assigned instead of msg_control and so
on.

Signed-off-by: Sebastian Gottschall <s.gottschall@dd-wrt.com>