### PR TITLE
Don't force -fstack-protector, the toolchain might lack support for it

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,9 +43,13 @@ DISABLE_WARNINGS = \
 
 AM_CFLAGS = \
 	-fno-strict-aliasing \
-	-fstack-protector \
 	$(ENABLE_WARNINGS) \
 	$(DISABLE_WARNINGS)
+
+if HAVE_STACK_PROTECTOR
+AM_CFLAGS += \
+	-fstack-protector
+endif
 
 ### CPP is C PreProcessor ###
 

--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,9 @@ dnl Determine CC and preset CFLAGS
 AC_PROG_CC_C99
 AC_PROG_RANLIB
 
+AC_ARG_WITH([stack-protector], AS_HELP_STRING([--without-stack-protector], [Build without -fstack-protector]),[],[with_stack_protector=yes])
+AM_CONDITIONAL(HAVE_STACK_PROTECTOR, test x"$with_stack_protector" = xyes)
+
 AC_ARG_WITH([check], AS_HELP_STRING([--without-check], [Build without check unit testing framework]),[],[with_check=no])
 AS_IF([test "x$with_check" = "xyes"], [
     AS_IF([test "x$arch" = "xlinux"], [


### PR DESCRIPTION
Signed-off-by: Gustavo Zacarias <gustavo@zacarias.com.ar>
Signed-off-by: Thomas Petazzoni <thomas.petazzoni@free-electrons.com>
[Retrieved (and slightly updated) from:
https://git.buildroot.net/buildroot/tree/package/radvd/0002-Don-t-force-fstack-protector-the-toolchain-might-lac.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>