### PR TITLE
Added ConditionPathExists=/etc/radvd.conf

### DIFF
--- a/radvd.service.in
+++ b/radvd.service.in
@@ -6,6 +6,7 @@
 Description=Router advertisement daemon for IPv6
 Documentation=man:radvd(8)
 After=network.target
+ConditionPathExists=/etc/radvd.conf
 
 [Service]
 Type=forking

--- a/redhat/systemd/radvd.service
+++ b/redhat/systemd/radvd.service
@@ -2,6 +2,7 @@
 Description=Router advertisement daemon for IPv6
 After=network-online.target
 Wants=network-online.target
+ConditionPathExists=/etc/radvd.conf
 
 [Service]
 EnvironmentFile=/etc/sysconfig/radvd


### PR DESCRIPTION
Adding ConditionPathExists=/etc/radvd.conf prevents that systemd
starts the service when no /etc/radvd.conf exists.

Reported-by: Nick Huber <nick.huber@multapplied.net>
Signed-off-by: Geert Stappers <stappers@debian.org>